### PR TITLE
stack: fix possible stack buffer overflow

### DIFF
--- a/source/concurrent.c
+++ b/source/concurrent.c
@@ -209,7 +209,7 @@ ConcurrentContext_Construct(ConcurrentContext *aContext,
     }
     aContext->mProcedure = aProcedure;
     aContext->mStackBuffer = (unsigned char *)((Concurrent_CPURegister_t)(aStackBuffer + 15) & ~15);
-    aContext->mStackSize = aStackSize & ~15;
+    aContext->mStackSize = (aStackSize + aStackBuffer - aContext->mStackBuffer) & ~15;
     aContext->mUserPtr = aUserPtr;
 
     /* TODO: stack direction */


### PR DESCRIPTION
Oups, I just blindly updated the old code and didn't realized that if stack size is multiple of 16, but the stack is not aligned, only the stack beginning is corrected, not it's size. Thus the first push into the stack will overflow the buffer.
