### PR TITLE
Removed mCallerReturnAddress Instructions.

### DIFF
--- a/source/arch/arm/concurrent_arch.asm
+++ b/source/arch/arm/concurrent_arch.asm
@@ -70,10 +70,6 @@ ConcurrentArch_TrampolineToProcedure:
 
     ldr r1, global_var
 
-    @ save Return Address
-    ldr r2, [r1, #+8]   @ ConcurrentContext_Offsetof_CallerReturnAddress
-    str lr, [r0, r2]    @ mCallerReturnAddress = lr
-
     @ exchange stack
     ldr r2, [r1, #+4]   @ ConcurrentContext_Offsetof_StackPointer
     ldr r3, [r0, r2]    @ r3 = mStackPointer


### PR DESCRIPTION
:D Based on your tips, i removed these instructions which saves caller Link Register into aContext->mCallerReturnAddress. I thought it was meant for debugging purposes but as you mentioned, we can remove the instructions because lr is saved into stack at L68. 
Thanks