### PR TITLE
new API for detecting Stack Growth and removed mCallerReturnAddress Instruction for ARM. 

### DIFF
--- a/include/concurrent/concurrent.h
+++ b/include/concurrent/concurrent.h
@@ -55,6 +55,9 @@ Concurrent_Finalize(void);
 CONCURRENT_API const char *
 Concurrent_GetStatusString(ConcurrentStatus aStatus);
 
+CONCURRENT_API int
+Concurrent_GetStackDirection(int);
+
 CONCURRENT_API void
 Concurrent_GetModuleInfo(int *outVersionMajor,
                          int *outVersionMinor,

--- a/include/concurrent/short_lower_case_api.h
+++ b/include/concurrent/short_lower_case_api.h
@@ -12,6 +12,7 @@
 #define concurrent_init Concurrent_Initialize
 #define concurrent_fin Concurrent_Finalize
 #define concurrent_get_status_str Concurrent_GetStatusString
+#define concurrent_get_stackdirection Concurrent_GetStackDirection
 #define concurrent_get_module_info Concurrent_GetModuleInfo
 #define ctx_sizeof ConcurrentContext_SizeOf
 #define ctx_construct ConcurrentContext_Construct

--- a/source/arch/arm/concurrent_arch.asm
+++ b/source/arch/arm/concurrent_arch.asm
@@ -70,10 +70,6 @@ ConcurrentArch_TrampolineToProcedure:
 
     ldr r1, global_var
 
-    @ save Return Address
-    ldr r2, [r1, #+8]   @ ConcurrentContext_Offsetof_CallerReturnAddress
-    str lr, [r0, r2]    @ mCallerReturnAddress = lr
-
     @ exchange stack
     ldr r2, [r1, #+4]   @ ConcurrentContext_Offsetof_StackPointer
     ldr r3, [r0, r2]    @ r3 = mStackPointer

--- a/source/concurrent.c
+++ b/source/concurrent.c
@@ -120,6 +120,22 @@ Concurrent_GetStatusString(ConcurrentStatus aStatus)
     return status_strs[aStatus];
 }
 
+#pragma GCC diagnostic ignored "-Wreturn-type"
+CONCURRENT_API int
+Concurrent_GetStackDirection(int iter)
+{
+	// 1 = grows downward
+	// 0 = grows upward
+	static unsigned long baseptr;
+	int depth;
+	if ( iter == 0 ) baseptr = (unsigned long) &depth;
+	if ( iter < 10 ) {
+		Concurrent_GetStackDirection(iter + 1);
+	} else {
+		return ( (unsigned long)&depth + (baseptr - (unsigned long)&depth) == baseptr ? 1 : 0  );
+	}
+}
+
 CONCURRENT_API void
 Concurrent_GetModuleInfo(int *outVersionMajor,
                          int *outVersionMinor,
@@ -153,7 +169,7 @@ Concurrent_GetModuleInfo(int *outVersionMajor,
         *outIsDebugBuild = 0;
 #endif
     }
-    if (outIsStackGrowthDownward) *outIsStackGrowthDownward = 1; /* TODO */
+    if (outIsStackGrowthDownward) *outIsStackGrowthDownward = Concurrent_GetStackDirection(0);
     if (outMinimumStackSize) *outMinimumStackSize = (unsigned long)CONCURRENT_MIN_STACK_SIZE;
 
     if (outLicenseName) *outLicenseName = "zlib License";

--- a/source/concurrent.c
+++ b/source/concurrent.c
@@ -126,14 +126,14 @@ Concurrent_GetStackDirection(int iter)
 {
 	// 1 = grows downward
 	// 0 = grows upward
-	static unsigned long baseptr;
-	int depth;
-	if ( iter == 0 ) baseptr = (unsigned long) &depth;
-	if ( iter < 10 ) {
-		Concurrent_GetStackDirection(iter + 1);
-	} else {
-		return ( (unsigned long)&depth + (baseptr - (unsigned long)&depth) == baseptr ? 1 : 0  );
-	}
+    static unsigned long baseptr;
+    int depth;
+    if ( iter == 0 ) baseptr = (unsigned long) &depth;
+    if ( iter < 10 ) {
+        Concurrent_GetStackDirection(iter + 1);
+    } else {
+        return ( (unsigned long)&depth + (baseptr - (unsigned long)&depth) == baseptr ? 1 : 0  );
+    }
 }
 
 CONCURRENT_API void


### PR DESCRIPTION
:D Based on your tips, i removed these instructions which saves caller Link Register into aContext->mCallerReturnAddress. I thought it was meant for debugging purposes but as you mentioned, we can remove the instructions because lr is saved into stack at L68. 

A new api is added to detect stack growth whether it is downward or upward , by recursion.
Here is the algorithm :

1. Save depth into baseptr as base stack pointer.
2. Recurs ( pushes previous registers into stack upon entry ) .
3. Compare baseptr with latest value of { int depth } . 
4. If Stack is descending then (baseptr - depth) must be positive and ( depth +  (baseptr - depth ) ) must be equal to baseptr, Otherwise Stack is ascending . 

Thanks