### PR TITLE
Make creating a FreeBSD port smoother

### DIFF
--- a/include/concurrent/shortname.h
+++ b/include/concurrent/shortname.h
@@ -17,7 +17,7 @@
 #define ctx_get_resume_value concurrent_get_resume_value
 #define yield_value concurrent_yield_with_value
 #define yield concurrent_yield
-#define ctx_get_yiled_value concurrent_get_yield_value
+#define ctx_get_yield_value concurrent_get_yield_value
 #define ctx_reset concurrent_reset
 #define ctx_get_user_ptr concurrent_get_user_ptr
 #define ctx_get_stack_used concurrent_get_stack_used

--- a/makefile
+++ b/makefile
@@ -61,6 +61,7 @@ endif
 ifeq ($(SYSTEM),FreeBSD)
  CC=cc
  LD=ld
+ PREFIX?=/usr/local
  ifeq ($(ARCH),amd64)
   ARCH=x86_64
   ARCH_BITS=64
@@ -72,6 +73,8 @@ ifeq ($(SYSTEM),FreeBSD)
   AS=as
   ASFLAGS=
  endif
+else
+ PREFIX?=/usr
 endif
 
 CFLAGS+=-Wall
@@ -82,10 +85,9 @@ CFLAGS+=-fno-stack-protector  # for Ubuntu gcc patch
 ifeq ($(DEBUG),yes)
  CFLAGS+=-DCONCURRENT_DEBUG
  CFLAGS+=-g -ggdb
-else
+else ifneq ($(SYSTEM),FreeBSD)
  CFLAGS+=-O2
 endif
-
 
 TARGET=libconcurrent.a
 INCDIR+=-I.
@@ -117,15 +119,15 @@ help:
 	@echo "make [clean|help|examples|test|install|uninstall]"
 
 install: $(TARGET)
-	install -Dm644 libconcurrent.a $(DESTDIR)/usr/lib/libconcurrent.a
-	install -Dm644 include/concurrent/concurrent.h $(DESTDIR)/usr/include/concurrent/concurrent.h
-	install -Dm644 include/concurrent/shortname.h $(DESTDIR)/usr/include/concurrent/shortname.h
+	install -Dm644 libconcurrent.a $(DESTDIR)$(PREFIX)/lib/libconcurrent.a
+	install -Dm644 include/concurrent/concurrent.h $(DESTDIR)$(PREFIX)/include/concurrent/concurrent.h
+	install -Dm644 include/concurrent/shortname.h $(DESTDIR)$(PREFIX)/include/concurrent/shortname.h
 
 uninstall:
-	rm $(DESTDIR)/usr/lib/libconcurrent.a
-	rm $(DESTDIR)/usr/include/concurrent/concurrent.h
-	rm $(DESTDIR)/usr/include/concurrent/shortname.h
-	rmdir $(DESTDIR)/usr/include/concurrent
+	rm $(DESTDIR)$(PREFIX)/lib/libconcurrent.a
+	rm $(DESTDIR)$(PREFIX)/include/concurrent/concurrent.h
+	rm $(DESTDIR)$(PREFIX)/include/concurrent/shortname.h
+	rmdir $(DESTDIR)$(PREFIX)/include/concurrent
 
 clean:
 	@$(MAKE) -C examples clean
@@ -147,4 +149,3 @@ depend:
 concurrent_arch.o: concurrent_arch.asm
 
 include depend.inc
-

--- a/makefile
+++ b/makefile
@@ -120,6 +120,7 @@ help:
 
 install: $(TARGET)
 	install -Dm644 libconcurrent.a $(DESTDIR)$(PREFIX)/lib/libconcurrent.a
+	mkdir -p $(DESTDIR)$(PREFIX)/include/concurrent
 	install -Dm644 include/concurrent/concurrent.h $(DESTDIR)$(PREFIX)/include/concurrent/concurrent.h
 	install -Dm644 include/concurrent/shortname.h $(DESTDIR)$(PREFIX)/include/concurrent/shortname.h
 


### PR DESCRIPTION
- Add PREFIX option to makefile to allow overriding of install
  location.  Currently installs into /usr whereas on FreeBSD 3rd-party
  software installs into /usr/local.
- Don't add -O2 to CFLAGS when on FreeBSD.  Optimizations are set by
  the ports system and can be overridden by users.

Once this is merged I'll create a FreeBSD port/package and submit it for inclusion in the ports tree.