### PR TITLE
Remove explicitly set CC and LD on FreeBSD

### DIFF
--- a/makefile
+++ b/makefile
@@ -59,8 +59,6 @@ endif
 
 # FreeBSD has its own uname -m style
 ifeq ($(SYSTEM),FreeBSD)
- CC=cc
- LD=ld
  DESTDIR?=/usr/local
  ifeq ($(ARCH),amd64)
   ARCH=x86_64


### PR DESCRIPTION
libconcurrent is now in the ports tree: https://www.freshports.org/devel/libconcurrent

There was some fallout from the package build on FreeBSD 9.  With the recent changes to the makefile we don't need to set CC and LD anymore on FreeBSD.  The problem is that this prevents setting of the correct compiler on FreeBSD 9.  I've just updated the port to remove those lines but it would be great if this can be merged :)