### PR TITLE
Support OS X

### DIFF
--- a/examples/strsplit.c
+++ b/examples/strsplit.c
@@ -70,7 +70,7 @@ int main(void)
     struct strsplit *s = strsplit_new(text, '|');
     struct split_position *p;
     while ((p = strsplit_next(s)) != NULL) {
-        printf("%.*s\n", p->len, p->s);
+        printf("%.*s\n", (int)p->len, p->s);
     }
     strsplit_del(s);
 

--- a/makefile
+++ b/makefile
@@ -21,7 +21,12 @@ ifeq ($(ARCH),)
 endif
 
 ifeq ($(SYSTEM),)
- SYSTEM=$(shell $(UNAME) -o)
+ SYSNAME=$(shell $(UNAME) -a)
+ ifeq ($(findstring Darwin, $(SYSNAME)), Darwin)
+  SYSTEM=Darwin
+ else
+  SYSTEM=$(shell $(UNAME) -o)
+ endif
 endif
 
 NASM_FLAGS=
@@ -32,6 +37,8 @@ ifeq ($(findstring true, $(eq $(SYSTEM),Cygwin), $(eq $(SYSTEM),MSys)), true)
  endif
 else ifeq ($(SYSTEM),GNU/Linux)
  NASM_FLAGS+=-f elf$(ARCH_BITS)
+else ifeq ($(SYSTEM),Darwin)
+ NASM_FLAGS+=-f macho$(ARCH_BITS) --prefix _
 else
  NASM_FLAGS+=-f elf$(ARCH_BITS)
 endif

--- a/src/arch/x86_64/concurrent_arch.asm
+++ b/src/arch/x86_64/concurrent_arch.asm
@@ -47,14 +47,15 @@ concurrent_arch_setup_execution_context:
     mov rcx, rdi
 
     ; exchange stack
-    mov rax, qword [concurrent_offsetof_stack_ptr]
+    mov rax, [rel concurrent_offsetof_stack_ptr]
     xchg rsp, qword [rcx + rax]
 
     push rcx                                 ; ctx for "return" or out of scope
     push rcx                                 ; ctx for yield
-    push concurrent_arch_return_at_procedure
+    lea rax, [rel concurrent_arch_return_at_procedure]
+    push rax
 
-    mov rax, qword [concurrent_offsetof_procedure]
+    mov rax, [rel concurrent_offsetof_procedure]
     push qword [rcx + rax] ; entry point
 
     ; initial register value
@@ -69,7 +70,7 @@ concurrent_arch_setup_execution_context:
     push rax  ; r15
 
     ; restore stack
-    mov rax, qword [concurrent_offsetof_stack_ptr]
+    mov rax, [rel concurrent_offsetof_stack_ptr]
     xchg rsp, qword [rcx + rax]
 
     ret
@@ -85,11 +86,11 @@ concurrent_arch_trampoline_to_procedure:
 
     ; save return address
     mov rdx, qword [rsp + 8 * 8]      ; return address of this function
-    mov rax, qword [concurrent_offsetof_caller_return_addr]
+    mov rax, [rel concurrent_offsetof_caller_return_addr]
     mov qword [rcx + rax], rdx
 
     ; exchange stack
-    mov rax, qword [concurrent_offsetof_stack_ptr]
+    mov rax, [rel concurrent_offsetof_stack_ptr]
     xchg rsp, qword [rcx + rax]
     nop
 
@@ -107,12 +108,12 @@ concurrent_arch_trampoline_to_caller:
     save_context
 
     ; exchange stack
-    mov rax, qword [concurrent_offsetof_stack_ptr]
+    mov rax, [rel concurrent_offsetof_stack_ptr]
     xchg qword [rcx + rax], rsp
     nop
 
     ; get return address
-    mov rax, qword [concurrent_offsetof_caller_return_addr]
+    mov rax, [rel concurrent_offsetof_caller_return_addr]
     mov rax, qword [rcx + rax]
 
     restore_context
@@ -130,12 +131,12 @@ concurrent_arch_return_at_procedure:
     save_context
 
     ; exchange stack
-    mov rax, qword [concurrent_offsetof_stack_ptr]
+    mov rax, [rel concurrent_offsetof_stack_ptr]
     xchg qword [rcx + rax], rsp
     nop
 
     ; get return address
-    mov rax, qword [concurrent_offsetof_caller_return_addr]
+    mov rax, [rel concurrent_offsetof_caller_return_addr]
     mov rax, qword [rcx + rax]
 
     restore_context

--- a/test/makefile
+++ b/test/makefile
@@ -11,7 +11,7 @@ else
 endif
 
 EXT=out
-ifeq ($(shell uname -o),Cygwin)
+ifeq ($(findstring Cygwin, $(shell uname -a)), Cygwin)
  EXT=exe
 endif
 


### PR DESCRIPTION
Use relative addressing in the assembly code. Remove warning in ``strsplit`` example. Add ``clock_gettime()`` substitute for ``time_slice1`` example. Don't use ``uname -o`` for Darwin in the makefiles. Tested on OS X 10.11.5/Core i7-4770HQ (x86_64) and for regressions on CentOS 7.1/Xeon E5-2699 v4 (x86_64).

I'd prefer to change the makefiles differently (don't use ``-o`` at all, instead use ``-a`` and ``findstring`` to parse the system name) but this is a more minimal change.

Edit: closes #9.